### PR TITLE
Fix for issue #434

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -1668,18 +1668,20 @@
 				c.width = width;
 				c.height = height;
 				var cctx = c.getContext('2d'),
-					scalePoint;
+					scalePoint = {x: 1, y: 1};
 
 				//scale needs to happen at the unit level to ensure crisp edges
 				patternTransform.transforms.forEach(function(transform){
 					if(transform.type === 'scale'){
-						scalePoint = transform.p;
 						c.width *= transform.p.x;
+						scalePoint.x = transform.p.x;
 						if(transform.p.y !== undefined){
 							c.height *= transform.p.y;
+							scalePoint.y = transform.p.y;
 						}
 						else{
 							c.height *= transform.p.x;
+							scalePoint.y = transform.p.x;
 						}
 						tempSvg.attributes['width'] = new svg.Property('width', c.width + 'px');
 						tempSvg.attributes['height'] = new svg.Property('height', c.height + 'px');


### PR DESCRIPTION
In `svg.Element.pattern.createPattern`, transforms from the `patternTransform` attribute were being applied to the pattern units instead of the pattern as a whole. I added a second step to pattern rasterization so that instead of providing a single transformed unit as a canvas pattern, a second canvas sized to the parent SVG is created, transformed, and then filled with the pattern. This is then provided as the pattern fill instead.

This pull request is primarily for supporting behavior when `patternUnits="userSpaceOnUse"`. I can look at supporting `objectBoundingBox` at some point, but since my test SVGs using the behavior look heinous on the browsers I've tested, it hasn't been a priority. I'll also provide a link to my test site as soon as I'm home from work.
