### PR TITLE
Parse svg as svg not xml when possible

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -231,8 +231,14 @@
 			}
 			else if (window.DOMParser)
 			{
-				var parser = new DOMParser();
-				return parser.parseFromString(xml, 'text/xml');
+				try {
+					var parser = new DOMParser();
+					return parser.parseFromString(xml, 'image/svg+xml');
+				}
+				catch(e){
+					parser = new DOMParser();
+					return parser.parseFromString(xml, 'text/xml');
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Fixes issues with Microsoft Edge browser when providing the SVG data as a string that must be parsed.

Previous to this change transform, color, fill, font-size and other attributes would be ignored resulting in incorrect image being created.
