### PR TITLE
Added check for valid "clipPath" type

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -1001,7 +1001,7 @@
 				// clip
 				if (this.style('clip-path', false, true).hasValue()) {
 					var clip = this.style('clip-path', false, true).getDefinition();
-					if (clip != null) clip.apply(ctx);
+					if (clip != null && clip.type == "clipPath") clip.apply(ctx); // added check for definition type
 				}
 
 				// opacity


### PR DESCRIPTION
If the definition isn't a valid clipType element, canvg bombs when calling apply(), so added the extra check. You can repro by setting the clip-path url to an ID that is not a <clipPath> element.

For example:

```
<circle cx="30" cy="30" r="20" id="cir1"/>
<rect x="10" y="10" width="100" height="100" clip-path="url(#cir1)"/>
```
