### PR TITLE
Prevent render of 'font' elements

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -2111,6 +2111,10 @@
 					}
 				}
 			}
+
+			this.render = function(ctx) {
+				// NO RENDER
+			}
 		}
 		svg.Element.font.prototype = new svg.Element.ElementBase;
 


### PR DESCRIPTION
If an SVG has an embedded SVG font, canvg currently renders all of the font's glyphs as if they were path elements (in addition to rendering the glyphs inline with the text).  This change prevents canvg from rendering the glyphs directly onto the canvas.

For comparison, of the other major SVG rendering engines that support SVG fonts, Batik and WebKit have the expected behavior.
