### PR TITLE
Fixed jsfiddle external resources links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example Demonstration
 [view here](http://canvg.github.io/canvg/examples/index.htm)
 Tested in Chrome, Firefox, Opera, and IE (through FlashCanvas)
 
-[jsfiddle playground](http://jsfiddle.net/L3hondLn/)
+[jsfiddle playground](http://jsfiddle.net/6r2jug6o/)
 
 Usage
 =====


### PR DESCRIPTION
This corrects the external resources links in the jsfiddle on the readme file.