### PR TITLE
Fixes for dashed lines

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -1189,7 +1189,7 @@
 
 				if (ctx != null) {
 					ctx.beginPath();
-					ctx.arc(cx, cy, r, 0, Math.PI * 2, true);
+					ctx.arc(cx, cy, r, 0, Math.PI * 2, false);
 					ctx.closePath();
 				}
 
@@ -1209,14 +1209,13 @@
 				var ry = this.attribute('ry').toPixels('y');
 				var cx = this.attribute('cx').toPixels('x');
 				var cy = this.attribute('cy').toPixels('y');
-
 				if (ctx != null) {
 					ctx.beginPath();
-					ctx.moveTo(cx, cy - ry);
-					ctx.bezierCurveTo(cx + (KAPPA * rx), cy - ry,  cx + rx, cy - (KAPPA * ry), cx + rx, cy);
+					ctx.moveTo(cx + rx, cy);
 					ctx.bezierCurveTo(cx + rx, cy + (KAPPA * ry), cx + (KAPPA * rx), cy + ry, cx, cy + ry);
 					ctx.bezierCurveTo(cx - (KAPPA * rx), cy + ry, cx - rx, cy + (KAPPA * ry), cx - rx, cy);
 					ctx.bezierCurveTo(cx - rx, cy - (KAPPA * ry), cx - (KAPPA * rx), cy - ry, cx, cy - ry);
+					ctx.bezierCurveTo(cx + (KAPPA * rx), cy - ry,  cx + rx, cy - (KAPPA * ry), cx + rx, cy);
 					ctx.closePath();
 				}
 

--- a/canvg.js
+++ b/canvg.js
@@ -976,7 +976,7 @@
 					else if (typeof ctx.webkitLineDash != 'undefined') { ctx.webkitLineDash = gaps; }
 					else if (typeof ctx.mozDash != 'undefined' && !(gaps.length==1 && gaps[0]==0)) { ctx.mozDash = gaps; }
 
-					var offset = this.style('stroke-dashoffset').numValueOrDefault(0);
+					var offset = this.style('stroke-dashoffset').toPixels(null);
 					if (typeof ctx.lineDashOffset != 'undefined') { ctx.lineDashOffset = offset; }
 					else if (typeof ctx.webkitLineDashOffset != 'undefined') { ctx.webkitLineDashOffset = offset; }
 					else if (typeof ctx.mozDashOffset != 'undefined') { ctx.mozDashOffset = offset; }

--- a/canvg.js
+++ b/canvg.js
@@ -976,7 +976,7 @@
 					else if (typeof ctx.webkitLineDash != 'undefined') { ctx.webkitLineDash = gaps; }
 					else if (typeof ctx.mozDash != 'undefined' && !(gaps.length==1 && gaps[0]==0)) { ctx.mozDash = gaps; }
 
-					var offset = this.style('stroke-dashoffset').numValueOrDefault(1);
+					var offset = this.style('stroke-dashoffset').numValueOrDefault(0);
 					if (typeof ctx.lineDashOffset != 'undefined') { ctx.lineDashOffset = offset; }
 					else if (typeof ctx.webkitLineDashOffset != 'undefined') { ctx.webkitLineDashOffset = offset; }
 					else if (typeof ctx.mozDashOffset != 'undefined') { ctx.mozDashOffset = offset; }


### PR DESCRIPTION
Fixes the bug with dashed lines and paths when stroke-dashoffset is not specified. See comments of issue #454. According to the [SVG specification](https://www.w3.org/TR/SVG11/painting.html#StrokeDashoffsetProperty) the default stroke-dashoffset is 0. 

fix #454 close #455 fix #473