### PR TITLE
Added try...catch block to avoid crash with invalid css selectors

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -213,7 +213,7 @@
 			if(window.XMLHttpRequest){AJAX=new XMLHttpRequest();}
 			else{AJAX=new ActiveXObject('Microsoft.XMLHTTP');}
 			if(AJAX){
-			   AJAX.open('GET',url,false);
+			   AJAX.open('GET',url,true);
 			   AJAX.send(null);
 			   return AJAX.responseText;
 			}
@@ -855,7 +855,14 @@
 			this.addStylesFromStyleDefinition = function () {
 				// add styles
 				for (var selector in svg.Styles) {
-					if (selector[0] != '@' && matchesSelector(node, selector)) {
+					var selectorMatch
+					try {
+						selectorMatch = matchesSelector(node, selector);
+					}
+					catch (e) {
+						selectorMatch = false;
+					}
+					if (selectorMatch) {
 						var styles = svg.Styles[selector];
 						var specificity = svg.StylesSpecificity[selector];
 						if (styles != null) {


### PR DESCRIPTION
Element.matches throws a Syntax Error when an invalid selector is passed. For example, '[ng:cloak]' which is added by angular.js will cause a failure in the canvas rendering. This change wraps the call in try...catch block, and returns false in the case of an exception.

See Issue #367 which is related.