### PR TITLE
Added checks if point & circle is undefined while render is called 

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -1694,8 +1694,12 @@
 
 			this.baseRender = this.render;
 			this.render = function(ctx, point, angle) {
-				ctx.translate(point.x, point.y);
-				if (this.attribute('orient').valueOrDefault('auto') == 'auto') ctx.rotate(angle);
+				if (point != undefined) {
+					ctx.translate(point.x, point.y);
+				}
+			 	if (angle != undefined) {
+					if (this.attribute('orient').valueOrDefault('auto') == 'auto') ctx.rotate(angle);
+				}
 				if (this.attribute('markerUnits').valueOrDefault('strokeWidth') == 'strokeWidth') ctx.scale(ctx.lineWidth, ctx.lineWidth);
 				ctx.save();
 
@@ -1714,7 +1718,9 @@
 				ctx.restore();
 				if (this.attribute('markerUnits').valueOrDefault('strokeWidth') == 'strokeWidth') ctx.scale(1/ctx.lineWidth, 1/ctx.lineWidth);
 				if (this.attribute('orient').valueOrDefault('auto') == 'auto') ctx.rotate(-angle);
-				ctx.translate(-point.x, -point.y);
+				 if (point != undefined) {
+					 ctx.translate(-point.x, -point.y);
+				 }
 			}
 		}
 		svg.Element.marker.prototype = new svg.Element.ElementBase;


### PR DESCRIPTION
Added checks if point & circle is undefined while render is called internally. 
It was earlier breaking for perfect SVG file & working fine now with undefined checks.