### PR TITLE
Improve regexp for compress spaces

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -205,7 +205,8 @@
 		svg.trim = function(s) { return s.replace(/^\s+|\s+$/g, ''); }
 
 		// compress spaces
-		svg.compressSpaces = function(s) { return s.replace(/[\s\r\t\n]+/gm,' '); }
+		// Ideographic space is not replaced
+		svg.compressSpaces = function(s) { return s.replace(/(?!\u3000)\s+/gm, ' '); }
 
 		// ajax
 		svg.ajax = function(url) {


### PR DESCRIPTION
- remove `\r\t\n`, `\s` contains `\r`, `\t` and `\n`
    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
    - > Equivalent to `[ \f\n\r\t\v\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]`
- add exclude `\u3000` (`Ideographic space` / `和字間隔`)
    - before: http://jsfiddle.net/L3hondLn/728/
    - after: http://jsfiddle.net/L3hondLn/730/