### PR TITLE
Convert all attribute names to lower case

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -858,7 +858,8 @@
 				// add attributes
 				for (var i=0; i<node.attributes.length; i++) {
 					var attribute = node.attributes[i];
-					this.attributes[attribute.nodeName] = new svg.Property(attribute.nodeName, attribute.value);
+					var attributeName = (attribute.nodeName || '').toLowerCase()
+					this.attributes[attributeName] = new svg.Property(attributeName, attribute.value);
 				}
 				
 				this.addStylesFromStyleDefinition();


### PR DESCRIPTION
fixes an issue with IE rendering: in some cases attribute nodeName is upper case which breaks rendering.