### PR TITLE
FIX Fallback to canvas.width and .height if SVG is not in DOM

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -3005,6 +3005,8 @@
 				svg.ViewPort.Clear();
 				if (ctx.canvas.parentNode) {
 					svg.ViewPort.SetCurrent(ctx.canvas.parentNode.clientWidth, ctx.canvas.parentNode.clientHeight);
+				} else if (ctx.canvas.width && ctx.canvas.height) {
+					svg.ViewPort.SetCurrent(ctx.canvas.width, ctx.canvas.height);
 				} else {
 					svg.ViewPort.SetCurrent(defaultClientWidth, defaultClientHeight);
 				}


### PR DESCRIPTION
Otherwise, there is no way to set the dimensions with [save-svg-as-png](https://github.com/exupero/saveSvgAsPng).