### PR TITLE
Fixing Webpack build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "canvg.js",
     "MIT-LICENSE.txt"
   ],
+  "browser": {
+    "jsdom": false,
+    "xmldom": false
+  },
   "dependencies": {
     "rgbcolor": "^1.0.1",
     "stackblur": "^1.0.0",


### PR DESCRIPTION
This causes Webpack to ignore `jsdom` and `xmldom` when bundling.

Fixes #583