### PR TITLE
Adding in TypeScript declaration file

### DIFF
--- a/canvg.d.ts
+++ b/canvg.d.ts
@@ -1,0 +1,21 @@
+export interface Options {
+    log?: boolean;
+    useCORS?: boolean;
+    ignoreMouse?: boolean;
+    ignoreDimensions?: boolean;
+    ignoreClear?: boolean;
+    ignoreAnimation?: boolean;
+    enableRedraw?: boolean;
+
+    offsetX?: number;
+    offsetY?: number;
+    scaleWidth?: number;
+    scaleHeight?: number;
+
+    renderCallback?: (dom: Document) => void;
+    forceRedraw?: () => boolean;
+}
+
+declare function canvg(target?: string | HTMLCanvasElement, s?: string | Document, opts?: Options): void;
+
+export default canvg;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "git://github.com/gabelerner/canvg.git"
   },
   "main": "canvg.js",
+  "types": "canvg.d.ts",
   "version": "1.0.0",
   "scripts": {
     "test" : "cd test; node testNode.js",


### PR DESCRIPTION
This causes canvg to work with TypeScript projects (with correct static typing).

It has no effect on non-TypeScript projects.