### PR TITLE
Fixes critical error on malformed "style" values

### DIFF
--- a/src/canvg.js
+++ b/src/canvg.js
@@ -972,9 +972,11 @@ function build(opts) {
         for (var i = 0; i < styles.length; i++) {
           if (svg.trim(styles[i]) != '') {
             var style = styles[i].split(':');
-            var name = svg.trim(style[0]);
-            var value = svg.trim(style[1]);
-            this.styles[name] = new svg.Property(name, value);
+            if(style.length > 1) {
+              var name = svg.trim(style[0]);
+              var value = svg.trim(style[1]);
+              this.styles[name] = new svg.Property(name, value);
+            }
           }
         }
       }


### PR DESCRIPTION
canvg would fail the whole conversion if `style` of any of the nodes would contain malformed value. This fix adds a check so such values are ignored.