### PR TITLE
fix for issue #709

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "11"
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libgif-dev

--- a/src/canvg.js
+++ b/src/canvg.js
@@ -522,7 +522,7 @@ function build(opts) {
 
   // points and paths
   svg.ToNumberArray = function (s) {
-    var a = (s || '').match(/-?(\d+(\.\d+)?|\.\d+)(?=\D|$)/gm) || [];
+    var a = (s || '').match(/-?(\d+(?:\.\d*(?:[eE][+-]?\d+)?)?|\.\d+)(?=\D|$)/gm) || [];
     for (var i = 0; i < a.length; i++) {
       a[i] = parseFloat(a[i]);
     }

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -13,6 +13,7 @@ test('ToNumberArray', (t) => {
   t.deepEqual(ToNumberArray("7 88.8"), [7, 88.8]);
   t.deepEqual(ToNumberArray("1,-2,3,14,5"), [1, -2, 3, 14, 5]);
   t.deepEqual(ToNumberArray(" 1 -0.2   ,3,.14,  5  "), [1, -0.2, 3, 0.14, 5]);
+  t.deepEqual(ToNumberArray("-1.83697e-16 -1 1 -1.83697e-16 0 100"), [-1.83697e-16, -1, 1, -1.83697e-16, 0, 100])
 
   // Should support the omission of superfluous separators
   t.deepEqual(ToNumberArray("5.5.5"), [5.5, 0.5]);


### PR DESCRIPTION
Hi,

Here is a simple regex change on `svg.ToNumberArray` function to also match numbers with scientific (exponential) notation.

fixes #709 