### PR TITLE
Improved text performance

### DIFF
--- a/src/canvg.js
+++ b/src/canvg.js
@@ -2328,7 +2328,9 @@ function build(opts) {
       for (var i = 0; i < this.children.length; i++) {
         this.renderChild(ctx, this, this, i);
       }
-      svg.Mouse.checkBoundingBox(this, this.getBoundingBox(ctx));
+      if (svg.opts['ignoreMouse'] != true) {
+        svg.Mouse.checkBoundingBox(this, this.getBoundingBox(ctx));
+      }
     }
 
     this.getAnchorDelta = function (ctx, parent, startI) {

--- a/src/canvg.js
+++ b/src/canvg.js
@@ -2481,11 +2481,15 @@ function build(opts) {
     }
 
     this.measureText = function (ctx) {
+      var text = this.getText();
+      if (text.length === 0) {
+        return 0
+      }
+
       var customFont = this.parent.style('font-family').getDefinition();
       if (customFont != null) {
         var fontSize = this.parent.style('font-size').numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize);
         var measure = 0;
-        var text = this.getText();
         if (customFont.isRTL) text = text.split('').reverse().join('');
         var dx = svg.ToNumberArray(this.parent.attribute('dx').value);
         for (var i = 0; i < text.length; i++) {
@@ -2498,7 +2502,7 @@ function build(opts) {
         return measure;
       }
 
-      var textToMeasure = svg.compressSpaces(this.getText());
+      var textToMeasure = svg.compressSpaces(text);
       if (!ctx.measureText) return textToMeasure.length * 10;
 
       ctx.save();
@@ -2699,8 +2703,12 @@ function build(opts) {
     }
 
     this.measureText = function (ctx, text) {
-      var customFont = this.parent.style('font-family').getDefinition();
       text = text || this.getText();
+      if (text.length === 0) {
+        return 0
+      }
+
+      var customFont = this.parent.style('font-family').getDefinition();
       if (customFont != null) {
         var fontSize = this.fontSize();
         var measure = 0;


### PR DESCRIPTION
Here is a pull request that improves the performance of text elements. Without these changes, each text/tspan element was measured up to three times.  For large SVGs with a lot of text this hurts the performance quite badly since measuring text is an expensive operation.

Here is what I changed:
* Don't call `Mouse.checkBoundingBox` (and `getBoundingBox`) in `text.renderChildren` when `ignoreMouse` option is set to `true`
* Don't measure empty strings (return `0`) (`tSpan.getText()` returns an empty string when it has child elements)
* Cache measured text widths so subsequent calls to `measureText` will not measure the text again