### PR TITLE
add additional checks to base render

### DIFF
--- a/src/canvg.js
+++ b/src/canvg.js
@@ -917,7 +917,7 @@ function build(opts) {
       if (this.style('mask').hasValue()) { // mask
         var mask = this.style('mask').getDefinition();
         if (mask != null) mask.apply(ctx, this);
-      } else if (this.style('filter').hasValue() && this.style('filter').value && this.style('filter').value !== 'none' && this.style('filter').value !== 'undefined') { // filter
+      } else if (this.style('filter').valueOrDefault('none') !== 'none') { // filter
         var filter = this.style('filter').getDefinition();
         if (filter != null) filter.apply(ctx, this);
       } else {

--- a/src/canvg.js
+++ b/src/canvg.js
@@ -914,10 +914,10 @@ function build(opts) {
       if (this.style('visibility').value == 'hidden') return;
 
       ctx.save();
-      if (this.style('mask').hasValue()) { // mask
+      if (this.style('mask').hasValue() && this.style('mask').value && this.style('mask').value !== 'none' && this.style('mask').value !== 'undefined') { // mask
         var mask = this.style('mask').getDefinition();
         if (mask != null) mask.apply(ctx, this);
-      } else if (this.style('filter').hasValue()) { // filter
+      } else if (this.style('filter').hasValue() && this.style('filter').value && this.style('filter').value !== 'none' && this.style('filter').value !== 'undefined') { // filter
         var filter = this.style('filter').getDefinition();
         if (filter != null) filter.apply(ctx, this);
       } else {

--- a/src/canvg.js
+++ b/src/canvg.js
@@ -914,7 +914,7 @@ function build(opts) {
       if (this.style('visibility').value == 'hidden') return;
 
       ctx.save();
-      if (this.style('mask').hasValue() && this.style('mask').value && this.style('mask').value !== 'none' && this.style('mask').value !== 'undefined') { // mask
+      if (this.style('mask').hasValue()) { // mask
         var mask = this.style('mask').getDefinition();
         if (mask != null) mask.apply(ctx, this);
       } else if (this.style('filter').hasValue() && this.style('filter').value && this.style('filter').value !== 'none' && this.style('filter').value !== 'undefined') { // filter


### PR DESCRIPTION
Firefox running "this.style('filter')" could return a object like
{
name: 'filter',
value: 'none'
}
This would cause canvg skips rendering the childrens.