### PR TITLE
- linting (LGTM): exclude unused variable

### DIFF
--- a/src/util/styles.ts
+++ b/src/util/styles.ts
@@ -59,7 +59,7 @@ export function getSelectorSpecificity(selector: string) {
 		.replace(/[\*\s\+>~]/g, ' ')
 		.replace(/[#\.]/g, ' ');
 
-	[currentSelector, delta] = findSelectorMatch(currentSelector, elementRegex);
+	[currentSelector, delta] = findSelectorMatch(currentSelector, elementRegex); // lgtm [js/useless-assignment-to-local]
 	specificity[2] += delta;
 
 	return specificity.join('');


### PR DESCRIPTION
In future PRs, if there are failures, you can find the code on how to exclude harmless warnings by visiting the https://lgtm.com/projects/g/canvg/canvg/?mode=list page and clicking the "eye" in the top right of any warning. Though this one is harmless, suppressing it helps note the introduction of serious issues.