### PR TITLE
Fix the crossOrigin problem when canvas.toDataURL

### DIFF
--- a/src/Document/Document.ts
+++ b/src/Document/Document.ts
@@ -58,7 +58,7 @@ async function createImage(src: string) {
 
 	const image = document.createElement('img');
 
-	// image.crossOrigin = 'Anonymous';
+	image.crossOrigin = 'Anonymous';
 
 	return new Promise<HTMLImageElement>((resolve, reject) => {
 		image.onload = () => {


### PR DESCRIPTION
I got the canvas after v.render({...}), and then I use the canvas to carry out "canvas.toDataURL('image/jpeg', 1)", it was failed, hint me:
"DOMException: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported.".
 And I'm sure the server of img has set the header: Access-Control-Allow-Origin: *;
The solution is not only config the response header allow-origin, but also set the crossOrigin for the image in the canvg;