### PR TITLE
Fix for issue #948

### DIFF
--- a/src/Document/TextElement.ts
+++ b/src/Document/TextElement.ts
@@ -442,7 +442,10 @@ export default class TextElement extends RenderedElement {
 
 		const child = this.adjustChildCoordinates(ctx, textParent, parent, i);
 		const boundingBox = child.getBoundingBox(ctx);
-
+		if (!child.getBoundingBox) {
+			return null;
+		}
+		
 		if (!boundingBox) {
 			return null;
 		}


### PR DESCRIPTION
This commit fixes the issue with problems related to text elements.
If the function getchildboundingbox is not defined on a textelement's
child, before the getboundingbox of all parent elements fail. Therefore,
a check is introduced, if the function getchildboundingbox exists.