### PR TITLE
Fix an issue with FusionCharts on IE11

### DIFF
--- a/test/browser/v2/canvg.js
+++ b/test/browser/v2/canvg.js
@@ -269,6 +269,8 @@
 	      xmlDoc.loadXml(xml, settings);
 	      return xmlDoc;
 	    } else if (windowEnv.DOMParser) {
+	      // get rid of these potentially dupe attributes or IE11 fails -- BRH
+	      xml = xml.replace(/xmlns\=\".*?\"/g, '');
 	      try {
 	        var parser = opts.xmldom ? new windowEnv.DOMParser(opts.xmldom) : new windowEnv.DOMParser();
 	        return parser.parseFromString(xml, 'image/svg+xml');


### PR DESCRIPTION
FusionCharts generates SVG elements with two xlmns attributes. This breaks IE11's DOM parser. This fix removes all the xlmns elements in the XML source.