### PR TITLE
Enhancement: Canvg.fromSVGElement

### DIFF
--- a/src/Canvg.ts
+++ b/src/Canvg.ts
@@ -61,6 +61,27 @@ export default class Canvg {
 	}
 
 	/**
+	 * Create Canvg instance from SVG root element.
+	 * @param ctx - Rendering context.
+	 * @param svg - SVG root element.
+	 * @param options - Rendering options.
+	 * @returns Canvg instance.
+	 */
+	static fromSVGElement(
+		ctx: RenderingContext2D,
+		svg: SVGSVGElement,
+		options: IOptions = {}
+	) {
+		/* HACK: Mimic DOMDocument just enough to work with current Canvg constructor.
+		 * @ts-expect-error @ts-ignore */
+		const svgDocument = {
+			documentElement: svg
+		} as DOMDocument;
+
+		return new Canvg(ctx, svgDocument, options);
+	}
+
+	/**
 	 * XML/HTML parser instance.
 	 */
 	readonly parser: Parser;


### PR DESCRIPTION
Adds class method `fromSVGElement` for creating `Canvg` instance from SVG DOM element.

Fixes #1361 

NOTE: This is a feature that calls for committing to supporting DOM SVG as an input source, meaning decision to merge or not should take this into account.