### PR TITLE
Cater transform on clipPath element

### DIFF
--- a/src/Document/ClipPathElement.ts
+++ b/src/Document/ClipPathElement.ts
@@ -16,6 +16,7 @@ export default class ClipPathElement extends Element {
 		const {
 			document
 		} = this;
+		const transform = Transform.fromElement(document, this);
 		const contextProto = Reflect.getPrototypeOf(ctx) as RenderingContext2D;
 		const {
 			beginPath,
@@ -28,6 +29,10 @@ export default class ClipPathElement extends Element {
 		}
 
 		Reflect.apply(beginPath, ctx, []);
+
+		if (transform) {
+			transform.apply(ctx);
+		}
 
 		this.children.forEach((child: UseElement) => {
 			if (typeof child.path === 'undefined') {
@@ -56,6 +61,10 @@ export default class ClipPathElement extends Element {
 				transform.unapply(ctx);
 			}
 		});
+
+		if (transform) {
+			transform.unapply(ctx);
+		}
 
 		Reflect.apply(closePath, ctx, []);
 		ctx.clip();


### PR DESCRIPTION
`transform` attribute is allowed on `<clipPath>` element and should be honored.

```xml
<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
  <defs>
    <style>
      .circle{clip-path: url(#clip-path);}
    </style>
    <clipPath id="clip-path" transform="translate(50)">
      <circle cx="50" cy="50" r="50" />
    </clipPath>
  </defs>
  <rect width="100" height="100" fill="red" class="circle" />
</svg>
```
Incorrect result before fix:
![incorrect](https://user-images.githubusercontent.com/1825906/115697419-22406700-a396-11eb-9808-0867f36a7d37.png)
Correct result after fix:
![correct](https://user-images.githubusercontent.com/1825906/115697406-1f457680-a396-11eb-81f7-103ba885b0b9.png)
