### PR TITLE
FIX #1678: update isReadyLock state to fix deadlock on second render

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint": "eslint 'rollup.config.js' 'types/**/*.ts' 'test/**/*.{js,ts}' 'src/**/*.ts'",
     "jest": "cross-env NODE_ENV=test jest -c jest.config.json",
     "test:size": "size-limit",
-    "test:base": "run -p lint [ jest test/util ]",
+    "test:base": "run -p lint [ jest test/util test/canvg ]",
     "test:browser": "pnpm jest test/browser",
     "test:node": "pnpm jest test/node",
     "test:offscreen": "pnpm jest test/offscreen",

--- a/src/Screen.ts
+++ b/src/Screen.ts
@@ -301,9 +301,9 @@ export class Screen {
     const { mouse } = this
     const frameDuration = 1000 / Screen.FRAMERATE
 
+    this.isReadyLock = false
     this.frameDuration = frameDuration
     this.readyPromise = new Promise((resolve) => {
-      this.isReadyLock = false
       this.resolveReady = resolve
     })
 

--- a/src/Screen.ts
+++ b/src/Screen.ts
@@ -303,6 +303,7 @@ export class Screen {
 
     this.frameDuration = frameDuration
     this.readyPromise = new Promise((resolve) => {
+      this.isReadyLock = false
       this.resolveReady = resolve
     })
 

--- a/test/canvg.spec.ts
+++ b/test/canvg.spec.ts
@@ -18,18 +18,10 @@ describe('Canvg', () => {
       const c = preset.createCanvas(1280, 720) as canvas.Canvas
       const ctx = c.getContext('2d')
       const canvg = Canvg.fromString(ctx, svg, preset)
-      const result = await race({
-        render: async () => {
-          await canvg.render()
-          await canvg.render()
-        },
-        timeout: async () => {
-          await delay(200)
-        }
-      })
-
-      expect(result).toBe('render')
-    })
+      
+      await canvg.render()
+      await canvg.render()
+    }, 200)
   })
 })
 

--- a/test/canvg.spec.ts
+++ b/test/canvg.spec.ts
@@ -18,28 +18,9 @@ describe('Canvg', () => {
       const c = preset.createCanvas(1280, 720) as canvas.Canvas
       const ctx = c.getContext('2d')
       const canvg = Canvg.fromString(ctx, svg, preset)
-      
+
       await canvg.render()
       await canvg.render()
     }, 200)
   })
 })
-
-function delay(ms: number) {
-  return new Promise<void>((resolve) => {
-    setTimeout(() => resolve(), ms)
-  })
-}
-
-function race<TKey extends string>(fns: Record<TKey, () => Promise<void>>): Promise<TKey> {
-  return new Promise((resolve, reject) => {
-    Object.entries(fns).forEach(async ([key, fn]: [TKey, () => Promise<void>]) => {
-      try {
-        await fn()
-        resolve(key)
-      } catch (e) {
-        reject(e)
-      }
-    })
-  })
-}

--- a/test/canvg.spec.ts
+++ b/test/canvg.spec.ts
@@ -1,0 +1,53 @@
+import path from 'path'
+import { promises as fs } from 'fs'
+import { DOMParser } from 'xmldom'
+import * as canvas from 'canvas'
+import fetch from 'node-fetch'
+import { Canvg, presets } from '../src'
+
+const preset = presets.node({
+  DOMParser,
+  canvas,
+  fetch
+})
+
+describe('Canvg', () => {
+  describe('render', () => {
+    it('should render twice without deadlock', async () => {
+      const svg = await fs.readFile(path.join(__dirname, 'svgs/favicon.svg'), 'utf8')
+      const c = preset.createCanvas(1280, 720) as canvas.Canvas
+      const ctx = c.getContext('2d')
+      const canvg = Canvg.fromString(ctx, svg, preset)
+      const result = await race({
+        render: async () => {
+          await canvg.render()
+          await canvg.render()
+        },
+        timeout: async () => {
+          await delay(200)
+        }
+      })
+
+      expect(result).toBe('render')
+    })
+  })
+})
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), ms)
+  })
+}
+
+function race<TKey extends string>(fns: Record<TKey, () => Promise<void>>): Promise<TKey> {
+  return new Promise((resolve, reject) => {
+    Object.entries(fns).forEach(async ([key, fn]: [TKey, () => Promise<void>]) => {
+      try {
+        await fn()
+        resolve(key)
+      } catch (e) {
+        reject(e)
+      }
+    })
+  })
+}


### PR DESCRIPTION
calling "render()" twice fixes some render issues (see #1678 ).
This update fixes deadlock on calling second "render()".