### PR TITLE
chore: feColorMatrix for srgb, and fix inconsistent part with browser…

### DIFF
--- a/src/Document/Element.ts
+++ b/src/Document/Element.ts
@@ -171,8 +171,16 @@ export abstract class Element {
       const filter = this.getStyle('filter').getDefinition<FilterElement>()
 
       if (filter) {
+        if (!filter.children.length) {
+          return
+        }
+
         this.applyEffects(ctx)
         filter.apply(ctx, this)
+      } else {
+        this.setContext(ctx)
+        this.renderChildren(ctx)
+        this.clearContext(ctx)
       }
     } else {
       this.setContext(ctx)

--- a/src/Document/FeColorMatrixElement.ts
+++ b/src/Document/FeColorMatrixElement.ts
@@ -123,6 +123,13 @@ export class FeColorMatrixElement extends Element {
     } = this
     const srcData = ctx.getImageData(0, 0, width, height)
 
+    if (srcData.colorSpace === 'srgb') {
+      matrix[4] *= 255
+      matrix[9] *= 255
+      matrix[14] *= 255
+      matrix[19] *= 255
+    }
+
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
         const r = imGet(srcData.data, x, y, width, height, 0)

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -90,6 +90,7 @@
                   <option value="31.svg">links</option>
                   <option value="32.svg">images</option>
                   <option value="favicon.svg">favicon</option>
+                  <option value="facebook.svg">facebook</option>
                 </optgroup>
               </select>
               <select name="issues">

--- a/test/svgs/facebook.svg
+++ b/test/svgs/facebook.svg
@@ -1,0 +1,17 @@
+<svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_1981_8906)">
+<rect x="7.5" y="4" width="22.2966" height="22.2966" rx="11.1483" fill="#1877F2"/>
+</g>
+<path d="M19.5346 20.5975V15.6263H21.2872L21.5496 13.6889H19.5345V12.452C19.5345 11.891 19.6981 11.5088 20.543 11.5088L21.6205 11.5083V9.77555C21.4342 9.75198 20.7945 9.69922 20.0504 9.69922C18.4968 9.69922 17.4331 10.6021 17.4331 12.2601V13.6889H15.676V15.6263H17.4331V20.5974H19.5346V20.5975Z" fill="white"/>
+<defs>
+<filter id="filter0_d_1981_8906" x="0.0678005" y="0.2839" width="37.161" height="37.1608" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.7161"/>
+<feGaussianBlur stdDeviation="3.7161"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0941176 0 0 0 0 0.466667 0 0 0 0 0.94902 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1981_8906"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1981_8906" result="shape"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
as in facebook.svg, i found that:
1. <filter> tag with no children, canvg render the svg but browser don't
2. filter id specified in <g>, browser render the svg but canvg don't
3. color incorrect with srgb colorSpace, after denorming the last column of matrix got the excalty same hex value with filled color in <rect>

chrome version 130.0.6723.59, darwin-arm64